### PR TITLE
correcting the xlabel axis on bloch sphere

### DIFF
--- a/Chapter02/SimulatingQubits.ipynb
+++ b/Chapter02/SimulatingQubits.ipynb
@@ -207,7 +207,7 @@
     "    ax.set_xlim([-1,1])\n",
     "    ax.set_ylim([-1,1])\n",
     "    ax.set_zlim([-1,1])\n",
-    "    ax.set_xlabel('x: |\"-\"> to |\"+\">')\n",
+    "    ax.set_xlabel('x: |\"+\"> to |\"-\">')\n",
     "    ax.set_ylabel('y: |\"↺\"> to |\"↻\">')\n",
     "    ax.set_zlabel('z: |\"1\"> to |\"0\">')\n",
     "    ax.view_init(azim=20)\n",


### PR DESCRIPTION
if i am following this example correctly, the xlabel axis is inversed -/+ and this correction fixes that